### PR TITLE
chore: maintainer sync toolkit 0.4.3

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,6 @@
 name: Pull Request
 
 on:
-  workflow_dispatch:
   pull_request:
     types:
       - opened
@@ -63,14 +62,7 @@ jobs:
 
       - name: Semgrep scan
         run: |
-          if [ -n "${{ github.event.pull_request.base.sha }}" ]; then
-            BASELINE="${{ github.event.pull_request.base.sha }}"
-          else
-            BASE="${{ github.event.repository.default_branch }}"
-            git config --global --add safe.directory "$(pwd)"
-            git fetch origin "${BASE}"
-            BASELINE="$(git merge-base HEAD "origin/${BASE}")"
-          fi
+          BASELINE="${{ github.event.pull_request.base.sha }}"
           semgrep scan \
             --config p/ci \
             --config p/python \

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ virtualenv:
 	@./virtualenv/bin/python3 -m pip install -r requirements.txt
 
 # >>> rosey-maintainer:ops-docker BEGIN
-# Managed by rosey-maintainer-tools 0.4.2. Do not edit directly.
+# Managed by rosey-maintainer-tools 0.4.3. Do not edit directly.
 
 PROJECT_NAME ?= dockershelf
 all_ps_hashes = $(shell docker ps -q)
@@ -91,7 +91,7 @@ test: start
 	@$(exec_on_docker) tox -e coverage
 
 # >>> rosey-maintainer:ops-release BEGIN
-# Managed by rosey-maintainer-tools 0.4.2. Do not edit directly.
+# Managed by rosey-maintainer-tools 0.4.3. Do not edit directly.
 
 release:
 	@./scripts/release.sh $${VERSION_TYPE}

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Shared release gates for release scripts.
-# Managed by rosey-maintainer-tools 0.4.2. Do not edit directly.
+# Managed by rosey-maintainer-tools 0.4.3. Do not edit directly.
 
 RELEASE_CI_WORKFLOW=${RELEASE_CI_WORKFLOW:-push.yml}
 RELEASE_CI_TIMEOUT_SECONDS=${RELEASE_CI_TIMEOUT_SECONDS:-2700}


### PR DESCRIPTION
## Summary
- Remove `workflow_dispatch` from `pr.yml` (CI retriggers via `pull_request` `synchronize` only).
- Simplify managed **Code Quality** Semgrep job to use `github.event.pull_request.base.sha`.
- Toolkit **0.4.3** manifest + Makefile/lib.sh sync.

## Test plan
- [ ] **Pull Request** workflow runs on this PR (no dispatch trigger).
- [ ] **Code Quality** job passes.
- [ ] Rulesets already updated via `rosey-maintain protect-github --apply`.