### PR TITLE
fix: clean up pr-auto-merge workflow formatting

### DIFF
--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -1,9 +1,5 @@
 name: Pull Request Auto-Merge
 
-
-
-
-
 on:
   workflow_run:
     workflows:
@@ -11,9 +7,9 @@ on:
     types:
       - completed
     branches:
-      - 'feature/**'
-      - 'dependabot/**'
-      - '!release/**'
+      - "feature/**"
+      - "dependabot/**"
+      - "!release/**"
 
 jobs:
   gate:


### PR DESCRIPTION
## Summary

Remove extra blank lines after the workflow name and normalize branch pattern quotes from single to double quotes in `pr-auto-merge.yml`.

## Checklist

- [x] Tests, linting, or verification commands were run locally.
- [ ] Documentation was updated when behavior changed.
- [ ] Release notes or `RELEASE_DESCRIPTION` were updated when relevant.

## Verification

No behavioral change — formatting only.

## Notes for Maintainers

Cosmetic cleanup only. No logic changes.